### PR TITLE
Fix Header Responsiveness

### DIFF
--- a/themes/tinkerhub/less/partials/header.less
+++ b/themes/tinkerhub/less/partials/header.less
@@ -74,8 +74,8 @@
 // logo is centered in the header and the expand menu button
 // is displayed.
 @media screen and
-    (max-width: 800px),
-    (max-device-width: 800px) {
+    (max-width: 1024px),
+    (max-device-width: 1024px) {
 
     .header {
         grid-template-columns: auto;

--- a/themes/tinkerhub/static/index.css
+++ b/themes/tinkerhub/static/index.css
@@ -674,7 +674,7 @@ body {
   width: 32px;
   height: 32px;
 }
-@media screen and (max-width: 800px), (max-device-width: 800px) {
+@media screen and (max-width: 1024px), (max-device-width: 1024px) {
   .header {
     grid-template-columns: auto;
   }


### PR DESCRIPTION
The original responsive breakpoint was given as `800px`. However, the header becomes squashed way before it reaches that breakpoint. The image below shows the page at a width of `888px`.

<img width="1060" alt="before" src="https://user-images.githubusercontent.com/44024553/117685123-3fb56380-b1d3-11eb-902c-698f8c5059f8.png">

After some playing around, I think a width of `1024px` is much better for the responsiveness of the header.

Header just before the breakpoint at `1025px`:

<img width="1060" alt="after-1" src="https://user-images.githubusercontent.com/44024553/117685199-5360ca00-b1d3-11eb-854a-80b56aa2013d.png">

Header at `888px`:

<img width="1060" alt="after-2" src="https://user-images.githubusercontent.com/44024553/117685267-6378a980-b1d3-11eb-834b-aad682edf2fc.png">

