### PR TITLE
feat: Display github avatars of authors in learning path

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ hugo new path-name/subpath2.md
 | `sub` | Boolean | Specifies if a learning path is path or subpath | `false` |
 | `keywords` | Array | Search terms for the learning path, used by the search bar to do fuzzy search | `["python", "backend"]` |
 | `tags` | Array | Used to generate tag pages | `["python", "backend"]` |
+| `authors` | Array | github usernames of authors | `["author1", "author2"]` |
 
 ### License
 This project is licensed under [MIT License](LICENSE)

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -12,9 +12,8 @@ image: images/learning-path-name/image.png
 sub: false
 keywords: ["keyword1", "keyword2"]
 tags: ["tag1", "tag2"]
+authors: ["author1","author2"]
 ---
-
-A learning path for learning {insert-tech} curated by {insert-curator-github-username}
 
 ## Why learn X ❓
 Applications of {X}.

--- a/content/django/index.md
+++ b/content/django/index.md
@@ -7,11 +7,8 @@ image: images/django/django.jpg
 sub: false
 keywords: ["python", "django", "backend"]
 tags: ["python", "django", "backend"]
+authors: ["irenekurien"]
 ---
-
-<i> "The web framework for perfectionists with deadlines." </i> ✨
-<br><br>
-Learning path for Django curated by [Irene](https://github.com/irenekurien/)🎀
 
 ## Why learn Django ❓
 Django is a popular web framework built on top of python. It helps programmers rapidly create maintainable and flexiable web applications powered by an SQL Database. <br>

--- a/content/frontend/index.md
+++ b/content/frontend/index.md
@@ -7,9 +7,8 @@ image: images/frontend/fe.png
 sub: false
 keywords: ["web", "frontend", "html", "css", "javascipt"]
 tags: ["web", "frontend", "html", "css", "javascipt"]
+authors: ["akhilmhdh"]
 ---
-
-Learning path for Frontend Web Development curated by [Akhil](https://github.com/akhilmhdh/)🎀
 
 ## Install and setup stuffs 🚧
 

--- a/content/hacking/index.md
+++ b/content/hacking/index.md
@@ -7,9 +7,8 @@ image: images/hacking/hacker.jpg
 sub: false
 keywords: ["hacking", "bounty"]
 tags: ["hacking", "bounty"]
+authors: ["fasalmbt"]
 ---
-
-by [Fasal](https://github.com/fasalmbt/) 🕶️
 
 ### Programming Knowledge
 

--- a/content/html-css/index.md
+++ b/content/html-css/index.md
@@ -7,9 +7,8 @@ featured: false
 sub: false
 keywords: ["web", "frontend", "html", "css"]
 tags: ["web", "frontend", "html", "css"]
+authors: ["aka8921"]
 ---
-
-Learning path for HTML & CSS curated by [Vighnesh](https://github.com/aka8921/)🎀
 
 ## Why learn HTML & CSS ❓
 

--- a/themes/tinkerhub/layouts/_default/single.html
+++ b/themes/tinkerhub/layouts/_default/single.html
@@ -18,7 +18,17 @@
             <div class="image" style="background-image: url({{ .Site.BaseURL }}{{ .Params.image }});"></div>
             {{ end }}
             <header>
-                <h1>{{ .Title }} {{ if eq .Params.author true }}<small>by @{{ .Params.author }}</small>{{ end }}</h1>
+                <h1>{{ .Title }}</h1>
+                <section>
+                {{if .Params.authors}}
+                <p>Curated By</p>
+                {{range $author := .Params.authors}}
+                {{$url := printf "%s" $author | printf "%s%s" "https://github.com/" | printf "%s"}}
+                {{$imageurl := printf "%s" ".png?size=48" | printf "%s%s" $url}}
+                <a href={{$url}}><img class="avatar" src={{$imageurl}} alt={{ printf "%s" $author | printf "%s%s" "Avatar of " }}></a>
+                {{end}}
+                </section>
+                {{end}}
             </header>
             <section class="content">{{ .Content }}</section>
         </article>
@@ -32,9 +42,6 @@
                     <li>
                         <a href="{{ .RelPermalink }}">
                           <span class="name">{{ .Title }}</span>
-                            {{ if eq .Params.author true }}
-                            <span class="author">by @{{ .Params.author }}</span>
-                            {{ end }}
                         </a>
                     </li>
                     {{ end }}

--- a/themes/tinkerhub/less/layouts/single.less
+++ b/themes/tinkerhub/less/layouts/single.less
@@ -133,9 +133,7 @@
 
     article {
         header {
-            padding-bottom: 40px;
-            border-bottom: 2px solid #EFF0F2;
-            margin-bottom: 32px;
+            margin-bottom: 1em;
 
             h1 {
                 font-size: 32px;
@@ -320,6 +318,11 @@
     dd {
         margin-bottom: 24px;
     }
+}
+.avatar
+{
+    border-radius: 50%;
+    padding: 1em;
 }
 
 //

--- a/themes/tinkerhub/static/index.css
+++ b/themes/tinkerhub/static/index.css
@@ -221,9 +221,7 @@ body {
   display: none;
 }
 .single article header {
-  padding-bottom: 40px;
-  border-bottom: 2px solid #EFF0F2;
-  margin-bottom: 32px;
+  margin-bottom: 1em;
 }
 .single article header h1 {
   font-size: 32px;
@@ -380,6 +378,10 @@ body {
 }
 .content dd {
   margin-bottom: 24px;
+}
+.avatar {
+  border-radius: 50%;
+  padding: 1em;
 }
 .language-diff .gd,
 .language-patch .gd {


### PR DESCRIPTION
Changes:
*  Display author's Github avatar in learning path similar to Github's contributors list
*  Update template and readme to reflect this change
* Separate authors from content in applicable paths.

Screenshots:
![image](https://user-images.githubusercontent.com/46259660/118388805-29c8f800-b644-11eb-87e2-a18ce79aec7c.png)
